### PR TITLE
Some more improvements and important fix

### DIFF
--- a/src/me/drton/jmavsim/KinematicObject.java
+++ b/src/me/drton/jmavsim/KinematicObject.java
@@ -1,5 +1,7 @@
 package me.drton.jmavsim;
 
+import com.sun.j3d.loaders.IncorrectFormatException;
+import com.sun.j3d.loaders.ParsingErrorException;
 import com.sun.j3d.loaders.Scene;
 import com.sun.j3d.loaders.objectfile.ObjectFile;
 //import com.sun.j3d.utils.behaviors.mouse.MouseRotate;
@@ -12,8 +14,7 @@ import javax.media.j3d.TransformGroup;
 import javax.vecmath.Matrix3d;
 import javax.vecmath.Vector3d;
 
-import java.io.FileNotFoundException;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.net.URL;
 
 /**
@@ -53,31 +54,33 @@ public abstract class KinematicObject extends WorldObject {
      * @param modelFile file name
      * @throws java.io.FileNotFoundException
      */
-    protected void modelFromFile(String modelFile) throws FileNotFoundException {
+    protected void modelFromFile(String modelFile) {
         URL file = null;
         try {
             file = new URL("file:./" + modelFile);
-        } catch (MalformedURLException e) {
-            System.err.println(e);
-            System.exit(1);
-        }
-        ObjectFile objectFile = new ObjectFile();
-        Scene scene = objectFile.load(file);
         
-        BranchGroup bg = scene.getSceneGroup();
-        
-//        Shape3D shape = (Shape3D)bg.getChild(0);
-//        shape.setPickable(true);
-//        TransformGroup objRotate = new TransformGroup();
-//        objRotate.setCapability(TransformGroup.ALLOW_TRANSFORM_WRITE);
-//        objRotate.addChild(bg);
-//        MouseRotate f1=new MouseRotate();
-//        f1.setSchedulingBounds(new BoundingSphere());
-//        f1.setTransformGroup(objRotate);
-//        bg.addChild(f1);
-//        transformGroup.addChild(objRotate);
+            ObjectFile objectFile = new ObjectFile();
+            Scene scene = objectFile.load(file);
 
-        transformGroup.addChild(bg);
+//          Shape3D shape = (Shape3D)bg.getChild(0);
+//          shape.setPickable(true);
+//          TransformGroup objRotate = new TransformGroup();
+//          objRotate.setCapability(TransformGroup.ALLOW_TRANSFORM_WRITE);
+//          objRotate.addChild(bg);
+//          MouseRotate f1=new MouseRotate();
+//          f1.setSchedulingBounds(new BoundingSphere());
+//          f1.setTransformGroup(objRotate);
+//          bg.addChild(f1);
+//          transformGroup.addChild(objRotate);
+
+            BranchGroup bg = scene.getSceneGroup();
+            transformGroup.addChild(bg);
+            
+        } catch (IOException | IncorrectFormatException | ParsingErrorException e) {
+            System.out.println("ERROR: could not load 3D model: " + modelFile);
+            System.out.println("Error message:" + e.getLocalizedMessage());
+        }
+        
     }
 
     public BranchGroup getBranchGroup() {

--- a/src/me/drton/jmavsim/ReportPanel.java
+++ b/src/me/drton/jmavsim/ReportPanel.java
@@ -6,6 +6,7 @@ import java.awt.*;
  * A UI panel containing the simulation report.
  */
 public class ReportPanel extends Panel {
+    private static final long serialVersionUID = 8196526002006067676L;
     private final TextArea textArea;
 
     public ReportPanel() {

--- a/src/me/drton/jmavsim/ReportUpdater.java
+++ b/src/me/drton/jmavsim/ReportUpdater.java
@@ -7,21 +7,36 @@ public class ReportUpdater extends WorldObject {
     private static final long UPDATE_FREQ_MS = 250;
 
     private static final StringBuilder builder = new StringBuilder();
+    private static long updateFreq;
+    private static long nextUpdateT;
     private final Visualizer3D visualizer;
-    private long nextUpdateT;
 
 
     public ReportUpdater(World world, Visualizer3D visualizer) {
         super(world);
         this.visualizer = visualizer;
+        setUpdateFreq(UPDATE_FREQ_MS);
     }
 
+    public static long getUpdateFreq() {
+        return ReportUpdater.updateFreq;
+    }
+
+    public static void setUpdateFreq(long updateFreq) {
+        ReportUpdater.updateFreq = updateFreq;
+        ReportUpdater.nextUpdateT = System.currentTimeMillis() + updateFreq;
+    }
+
+    public static void resetUpdateFreq() {
+        setUpdateFreq(UPDATE_FREQ_MS);
+    }
+    
     @Override
     public void update(long t) {
         if (t < nextUpdateT)
             return;
 
-        nextUpdateT = t + UPDATE_FREQ_MS;
+        nextUpdateT = t + updateFreq;
         builder.setLength(0);
 
         for (WorldObject object : getWorld().getObjects()) {

--- a/src/me/drton/jmavsim/SerialMAVLinkPort.java
+++ b/src/me/drton/jmavsim/SerialMAVLinkPort.java
@@ -14,7 +14,7 @@ import java.nio.channels.ByteChannel;
  * User: ton Date: 28.11.13 Time: 23:30
  */
 public class SerialMAVLinkPort extends MAVLinkPort {
-    private MAVLinkSchema schema;
+    private MAVLinkSchema schema = null;
     private SerialPort serialPort = null;
     private ByteChannel channel = null;
     private MAVLinkStream stream = null;
@@ -50,6 +50,7 @@ public class SerialMAVLinkPort extends MAVLinkPort {
             serialPort.openPort();
             serialPort.setParams(baudRate, dataBits, stopBits, parity);
         } catch (SerialPortException e) {
+            serialPort = null;
             throw new IOException(e);
         }
         channel = new ByteChannel() {
@@ -57,16 +58,17 @@ public class SerialMAVLinkPort extends MAVLinkPort {
             public int read(ByteBuffer buffer) throws IOException {
                 try {
                     int available = serialPort.getInputBufferBytesCount();
-                    if (available <= 0) {
+                    if (available <= 0)
                         return 0;
-                    }
+
                     byte[] b = serialPort.readBytes(Math.min(available,buffer.remaining()));
                     if (b != null) {
                         buffer.put(b);
                         return b.length;
-                    } else {
-                        return 0;
                     }
+                    
+                    return 0;
+
                 } catch (SerialPortException e) {
                     throw new IOException(e);
                 }

--- a/src/me/drton/jmavsim/SystemOutHandler.java
+++ b/src/me/drton/jmavsim/SystemOutHandler.java
@@ -1,6 +1,6 @@
 package me.drton.jmavsim;
 
-import java.io.ByteArrayOutputStream;
+//import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;

--- a/src/me/drton/jmavsim/Visualizer3D.java
+++ b/src/me/drton/jmavsim/Visualizer3D.java
@@ -44,6 +44,7 @@ public class Visualizer3D extends JFrame {
     public static final boolean   AA_ENABLED = true;  // default antialising for 3D scene
     public static final ViewTypes VIEW_TYPE  = ViewTypes.VIEW_STATIC;  // default view type
     public static final ZoomModes ZOOM_MODE  = ZoomModes.ZOOM_DYNAMIC;  // default zoom type
+    public static final int       FPS_TARGET = 60;  // target frames per second
     
     private Dimension reportPanelSize = new Dimension(Math.min(WINDOW_SIZE.width / 2, 350), 200);
     private boolean reportPaused = false;
@@ -131,6 +132,7 @@ public class Visualizer3D extends JFrame {
 
         universe = new SimpleUniverse(canvas);
         view = universe.getViewer().getView();
+        view.setMinimumFrameCycleTime(1000 / FPS_TARGET);
         view.setBackClipDistance(WORLD_SIZE / 4);
         view.setSceneAntialiasingEnable(AA_ENABLED);
         view.setTransparencySortingPolicy(View.TRANSPARENCY_SORT_GEOMETRY);

--- a/src/me/drton/jmavsim/Visualizer3D.java
+++ b/src/me/drton/jmavsim/Visualizer3D.java
@@ -395,6 +395,7 @@ public class Visualizer3D extends JFrame {
         if (reportPanel == null || (on && reportPanel.isShowing()) || (!on && !reportPanel.isShowing()))
             return;
         
+        setReportPaused(!on);
         if (reportPanel.isShowing()) {
             reportPanelSize = reportPanel.getSize();
             splitPane.setLeftComponent(null);
@@ -421,6 +422,10 @@ public class Visualizer3D extends JFrame {
     public void setReportPaused(boolean pause) {
         reportPaused = pause;
         reportPanel.setIsFocusable(pause);
+        if (pause)
+            ReportUpdater.setUpdateFreq(0L);
+        else
+            ReportUpdater.resetUpdateFreq();
     }
 
     public void setShowOverlay(boolean showOverlay) {

--- a/src/me/drton/jmavsim/vehicle/AbstractMulticopter.java
+++ b/src/me/drton/jmavsim/vehicle/AbstractMulticopter.java
@@ -5,7 +5,6 @@ import me.drton.jmavsim.Rotor;
 import me.drton.jmavsim.World;
 
 import javax.vecmath.Vector3d;
-import java.io.FileNotFoundException;
 
 /**
  * Abstract multicopter class. Does all necessary calculations for multirotor with any placement of rotors.
@@ -16,7 +15,7 @@ public abstract class AbstractMulticopter extends AbstractVehicle {
     private double dragRotate = 0.0;
     protected Rotor[] rotors;
 
-    public AbstractMulticopter(World world, String modelName) throws FileNotFoundException {
+    public AbstractMulticopter(World world, String modelName) {
         super(world, modelName);
         rotors = new Rotor[getRotorsNum()];
         for (int i = 0; i < getRotorsNum(); i++) {

--- a/src/me/drton/jmavsim/vehicle/AbstractVehicle.java
+++ b/src/me/drton/jmavsim/vehicle/AbstractVehicle.java
@@ -9,7 +9,6 @@ import me.drton.jmavsim.World;
 
 import javax.vecmath.Vector3d;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +22,7 @@ public abstract class AbstractVehicle extends DynamicObject implements Reporting
     protected List<Double> control = Collections.emptyList();
     protected Sensors sensors = null;
 
-    public AbstractVehicle(World world, String modelName) throws FileNotFoundException {
+    public AbstractVehicle(World world, String modelName) {
         super(world);
         modelFromFile(modelName);
         resetObjectParameters();

--- a/src/me/drton/jmavsim/vehicle/Hexacopter.java
+++ b/src/me/drton/jmavsim/vehicle/Hexacopter.java
@@ -5,7 +5,6 @@ import me.drton.jmavsim.World;
 
 import javax.vecmath.Matrix3d;
 import javax.vecmath.Vector3d;
-import java.io.FileNotFoundException;
 
 /**
  * Generic hexacopter model.
@@ -25,10 +24,9 @@ public class Hexacopter extends AbstractMulticopter {
      * @param rotorTorque    torque at full thrust of one rotor
      * @param rotorTimeConst spin-up time of rotor
      * @param rotorsOffset   rotors positions offset from gravity center
-     * @throws FileNotFoundException if .obj model file not found
      */
     public Hexacopter(World world, String modelName, String orientation, double armLength, double rotorThrust,
-                      double rotorTorque, double rotorTimeConst, Vector3d rotorsOffset) throws FileNotFoundException {
+                      double rotorTorque, double rotorTimeConst, Vector3d rotorsOffset) {
         super(world, modelName);
         rotorPositions[0] = new Vector3d(armLength, 0.0, 0.0);
         rotorPositions[1] = new Vector3d(-armLength, 0.0, 0.0);

--- a/src/me/drton/jmavsim/vehicle/Quadcopter.java
+++ b/src/me/drton/jmavsim/vehicle/Quadcopter.java
@@ -5,7 +5,6 @@ import me.drton.jmavsim.World;
 
 import javax.vecmath.Matrix3d;
 import javax.vecmath.Vector3d;
-import java.io.FileNotFoundException;
 
 /**
  * Generic quadcopter model.
@@ -27,10 +26,9 @@ public class Quadcopter extends AbstractMulticopter {
      * @param rotorTorque    torque at full thrust of one rotor in [Nm]
      * @param rotorTimeConst spin-up time of rotor [s]
      * @param rotorsOffset   rotors positions offset from gravity center
-     * @throws FileNotFoundException if .obj model file not found
      */
     public Quadcopter(World world, String modelName, String orientation, String style, double armLength, double rotorThrust,
-                      double rotorTorque, double rotorTimeConst, Vector3d rotorsOffset) throws FileNotFoundException {
+                      double rotorTorque, double rotorTimeConst, Vector3d rotorsOffset) {
         super(world, modelName);
         
         int i;


### PR DESCRIPTION
The last commit in this series fixes a major issue when the 3D frame rate is unconstrained by the video driver -- the visualizer will consume too much time and possibly swamp the CPU therefore not allowing the sim data thread to run properly.  I wasn't aware of this because on my main dev box the FPS was already limited to 60 FPS by the video driver (matching monitor refresh rate).  

The other changes are general improvements to zoom feature, improved performance when report panel is hidden, add startup option to show gimbal or not, and much improved error trapping and reporting.  GUI now loads much earlier in the startup process and can show most errors/warnings there.  Now practical to run detached from console in Windows with `javaw` instead of `java`.

-Max