### PR TITLE
Change default mass of simulated vehicle from 0.8 to 1.0

### DIFF
--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -305,7 +305,7 @@ public class Simulator implements Runnable {
         I.m11 = 0.005;  // Y
         I.m22 = 0.009;  // Z
         vehicle.setMomentOfInertia(I);
-        vehicle.setMass(0.8);
+        vehicle.setMass(1.0); // mass of the vehicle, too light the vehicle will start climbing on arm
         vehicle.setDragMove(0.01);
         SimpleSensors sensors = new SimpleSensors();
         sensors.setGPSInterval(50);


### PR DESCRIPTION
The current default mass of simulated vehicle is 0.8, which causes a problem where the vehicle will start climbing as soon as it is armed. It turns out 0.8 is too light, the idle thrust is enough to accelerate the vehicle. This is fixed by changing the mass to 1.0.