### PR TITLE
Simulator.java: shutdown if serial port open fails

### DIFF
--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -244,7 +244,7 @@ public class Simulator implements Runnable {
         }
         catch (IOException e) {
             System.out.println("ERROR: Failed to open MAV port: " + e.getLocalizedMessage());
-//            shutdown = true;
+            shutdown = true;
         }
 
         if (COMMUNICATE_WITH_QGC) {


### PR DESCRIPTION
If we can't connect to the autopilot in HITL, we should not continue but
stop jMAVSim. Otherwise, the user won't realize that HITL is not actually
working and get confused.