### PR TITLE
Add simulation of optic flow

### DIFF
--- a/src/me/drton/jmavsim/FlowData.java
+++ b/src/me/drton/jmavsim/FlowData.java
@@ -1,0 +1,15 @@
+package me.drton.jmavsim;
+
+import javax.vecmath.Vector2d;
+import javax.vecmath.Vector3d;
+
+/**
+ * Created by v01d on 15/09/15.
+ */
+public class FlowData {
+    public long integration_time;
+    public Vector2d integrated_flow = new Vector2d();
+    public Vector3d integrated_gyro = new Vector3d();
+    public double distance;
+    public int quality;
+}

--- a/src/me/drton/jmavsim/LogPlayerSensors.java
+++ b/src/me/drton/jmavsim/LogPlayerSensors.java
@@ -87,6 +87,21 @@ public class LogPlayerSensors implements Sensors {
     }
 
     @Override
+    public double getSonarDist() {
+        return 0; // TODO: implement me
+    }
+
+    @Override
+    public FlowData getFlowData() {
+        return null; // TODO: implement me
+    }
+
+    @Override
+    public boolean isFlowUpdated() {
+        return false; // TODO: implement me
+    }
+
+    @Override
     public void update(long t) {
         if (logReader != null) {
             Map<String, Object> logData = new HashMap<String, Object>();

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -262,7 +262,6 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
         if (sensors.isFlowUpdated()) {
             FlowData flowData = sensors.getFlowData();
             if (flowData != null && flowData.integrated_flow != null && flowData.integrated_gyro != null) {
-            //if (true) {
                 MAVLinkMessage msg_flow = new MAVLinkMessage(schema, "HIL_OPTICAL_FLOW", sysId, componentId, protocolVersion);
                 msg_flow.set("time_usec", tu);
                 msg_flow.set("sensor_id", 0);

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -272,7 +272,7 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
                 msg_flow.set("integrated_xgyro", flowData.integrated_gyro.x);
                 msg_flow.set("integrated_ygyro", flowData.integrated_gyro.y);
                 msg_flow.set("integrated_zgyro", flowData.integrated_gyro.z);
-                msg_flow.set("temperature", 50);
+                msg_flow.set("temperature", 2000);
                 msg_flow.set("quality", flowData.quality);
                 msg_flow.set("time_delta_distance_us", flowData.integration_time);
                 msg_flow.set("distance", flowData.distance);

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -257,6 +257,28 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
             msg_system_time.set("time_boot_ms", tu/1000);
             sendMessage(msg_system_time);
         }
+        
+        // Optic flow
+        if (sensors.isFlowUpdated()) {
+            FlowData flowData = sensors.getFlowData();
+            if (flowData != null && flowData.integrated_flow != null && flowData.integrated_gyro != null) {
+            //if (true) {
+                MAVLinkMessage msg_flow = new MAVLinkMessage(schema, "HIL_OPTICAL_FLOW", sysId, componentId, protocolVersion);
+                msg_flow.set("time_usec", tu);
+                msg_flow.set("sensor_id", 0);
+                msg_flow.set("integration_time_us", flowData.integration_time);
+                msg_flow.set("integrated_x", flowData.integrated_flow.x);
+                msg_flow.set("integrated_y", flowData.integrated_flow.y);
+                msg_flow.set("integrated_xgyro", flowData.integrated_gyro.x);
+                msg_flow.set("integrated_ygyro", flowData.integrated_gyro.y);
+                msg_flow.set("integrated_zgyro", flowData.integrated_gyro.z);
+                msg_flow.set("temperature", 50);
+                msg_flow.set("quality", flowData.quality);
+                msg_flow.set("time_delta_distance_us", flowData.integration_time);
+                msg_flow.set("distance", flowData.distance);
+                sendMessage(msg_flow);
+            }
+        }
     }
 
 }

--- a/src/me/drton/jmavsim/Sensors.java
+++ b/src/me/drton/jmavsim/Sensors.java
@@ -20,11 +20,17 @@ public interface Sensors {
 
     double getPressure();
 
+    double getSonarDist();
+
     GNSSReport getGNSS();
 
     LatLonAlt getGlobalPosition();
 
     boolean isGPSUpdated();
+
+    FlowData getFlowData();
+
+    boolean isFlowUpdated();
 
     boolean isReset();
 


### PR DESCRIPTION
This adds a simulation of PX4Flow using HIL_OPTICAL_FLOW. This can be useful as jMAVSim is much lighter than gazebo.
I started from PR #9 which implemented sonar and sent optic flow=0, then added computation of optic flow.
I am far from being a java guru, so any input is welcome @v01d @LorenzMeier !
