### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Simple multirotor simulator with MAVLink protocol support
 ### Installation ###
 
 Requirements:
- * Java 6 or newer (JDK, http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+ * Java 7 or newer (JDK, http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
  * Java3D and JOGL/JOAL jars, including native libs for Linux (i586/64bit), Windows (i586/64bit) and Mac OS (universal) already included in this repository, no need to install it.
+ 
+ * libvecmath-java (for ubuntu)
 
 Clone repository and initialize submodules:
 ```


### PR DESCRIPTION
When I compile jMAVSim at Ubuntu 16.04.2 LTS, I found it require java7 + and libvecmath-java. For backward compatibility with Java 6, I think that lots of things should be changed.  So I think it is better to update the requirement of java version.

How about you?

Thanks
 