### PR TITLE
Removed special character in comment

### DIFF
--- a/src/me/drton/jmavsim/SimpleEnvironment.java
+++ b/src/me/drton/jmavsim/SimpleEnvironment.java
@@ -11,7 +11,7 @@ public class SimpleEnvironment extends Environment {
     public static final double Pb = 101325.0;  // static pressure at sea level [Pa]
     public static final double Tb = 288.15;    // standard temperature at sea level [K]
     public static final double Lb = -0.0065;   // standard temperature lapse rate [K/m]
-    public static final double M = 0.0289644;  // molar mass of Earth’s air [kg/mol]
+    public static final double M = 0.0289644;  // molar mass of Earth's air [kg/mol]
     public static final double G = 9.80665;    // gravity
     public static final double R = 8.31432;    // universal gas constant
 


### PR DESCRIPTION
The special character I removed causes errors in Javac on ubuntu:14.04. (I did not try other versions).

```
compile:
    [javac] Compiling 73 source files to /jMAVSim/out/production/jMAVSim
    [javac] /jMAVSim/src/me/drton/jmavsim/SimpleEnvironment.java:14: error: unmappable character for encoding ASCII
    [javac]     public static final double M = 0.0289644;  // molar mass of Earth???s air [kg/mol]
    [javac]                                                                      ^
```

This small change would allow to compile jMAVSim without previous manual modification and does not affect any functionality