### PR TITLE
MAVLinkHILSystem: remove cont. init on heartbeat

### DIFF
--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -126,15 +126,15 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
                     if (sysId < 0) {
                         sysId = msg.systemID;
                     }
+
+                    System.out.println("Init MAVLink");
+                    initMavLink();
+
                 } else if (sysId > -1 && sysId != msg.systemID) {
                     System.out.println("WARNING: Got heartbeat from system #" + Integer.toString(msg.systemID) +
                                        " but configured to only accept messages from system #" + Integer.toString(sysId) +
                                        ". Please change the system ID parameter to match in order to use HITL/SITL.");
                 }
-            }
-            if (gotHeartBeat) {
-                System.out.println("Init MAVLink");
-                initMavLink();
             }
             if ((msg.getInt("base_mode") & 128) == 0) {
                 vehicle.setControl(Collections.<Double>emptyList());


### PR DESCRIPTION
We shouldn't initialize every time we receive a heartbeat but only the first time. This worked for SITL because we only send heartbeats until initialized, however, for HITL we keep sending them.

Fixes https://github.com/PX4/Firmware/issues/11165.