### PR TITLE
Simulator: reduce default rate

### DIFF
--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -53,7 +53,7 @@ public class Simulator implements Runnable {
         true;   // send System.out messages to stdout (console) as well as any custom handlers (see SystemOutHandler)
     public static boolean DEBUG_MODE = false;
 
-    public static final int    DEFAULT_SIM_RATE = 500; // Hz
+    public static final int    DEFAULT_SIM_RATE = 250; // Hz
     public static final double    DEFAULT_SPEED_FACTOR = 1.0;
     public static final int    DEFAULT_AUTOPILOT_SYSID =
         -1; // System ID of autopilot to communicate with. -1 to auto set ID on first received heartbeat.


### PR DESCRIPTION
For lockstep we use a default rate of 250 Hz. Therefore, it makes sense to use this as a deafult rate as well. That way we can start it without passing on any options and it will work out of the box.

Fixes starting with:
```
./Tools/jmavsim_run.sh
```
and:
```
(cd build/px4_sitl_default && ninja none)
```