### PR TITLE
Simulator: fix default for QGC and SDK link

### DIFF
--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -39,8 +39,8 @@ public class Simulator implements Runnable {
     }
     private static Port PORT = Port.UDP;
 
-    public static boolean   COMMUNICATE_WITH_QGC  = true;   // open UDP port to QGC
-    public static boolean   COMMUNICATE_WITH_SDK  = true;   // open UDP port to SDK
+    public static boolean   COMMUNICATE_WITH_QGC  = false;   // open UDP port to QGC
+    public static boolean   COMMUNICATE_WITH_SDK  = false;   // open UDP port to SDK
     public static boolean   DO_MAG_FIELD_LOOKUP   =
         false;  // perform online mag incl/decl lookup for current position
     public static boolean   USE_GIMBAL            =


### PR DESCRIPTION
By default we should not open a link but only if the CLI arguments are set.

Found by @bkueng in #99.