### PR TITLE
display only for simulation-in-hardware

### DIFF
--- a/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
+++ b/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
@@ -1,0 +1,82 @@
+package me.drton.jmavsim;
+
+import me.drton.jmavlib.conversion.RotationConversion;
+import me.drton.jmavlib.mavlink.MAVLinkMessage;
+import me.drton.jmavlib.mavlink.MAVLinkSchema;
+import me.drton.jmavsim.vehicle.AbstractVehicle;
+
+import javax.vecmath.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+// import java.util.Calendar;
+// import java.util.TimeZone;
+
+/**
+ * MAVLinkDisplayOnly is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
+ * MAVLinkDisplayOnly should have the same sysID as the autopilot, but different componentId.
+ * It reads HIL_STATE_QUATERNION from the MAVLink and displays the vehicle position and attitude.
+ */
+public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
+
+    private boolean fistMsg=true;       // to detect the first MAVLink message
+    private double lat0;                // initial latitude (radians)
+    private double lon0;                // initial longitude (radians)
+    private double alt0;                // initial altitude (meters)
+    private double lat;                 // geodetic latitude (radians)
+    private double lon;                 // geodetic longitude (radians)
+    private double alt;                  // above sea level (meters)
+    private double [] quat={0.0,0.0,0.0,0.0};   // unit quaternion for attitude representation
+    private Double [] control = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+    private static final double EARTH_RADIUS=6371000.0;    // earth radius in meters
+
+    /**
+     * Create MAVLinkDisplayOnly, MAVLink system that sends simulated sensors to autopilot and passes controls from
+     * autopilot to simulator
+     *
+     * @param sysId       SysId of simulator should be the same as autopilot
+     * @param componentId ComponentId of simulator should be different from autopilot
+     * @param vehicle     vehicle to connect
+     */
+    public MAVLinkDisplayOnly(MAVLinkSchema schema, int sysId, int componentId, AbstractVehicle vehicle) {
+        super(schema, sysId, componentId, vehicle);
+    }
+
+    @Override
+    public void handleMessage(MAVLinkMessage msg) {
+        if ("HIL_STATE_QUATERNION".equals(msg.getMsgName())) {
+
+            if (fistMsg) {
+                fistMsg=false;
+                // we take the fist received position as initial position
+                lat0=Math.toRadians(msg.getDouble("lat")*1e-7);
+                lon0=Math.toRadians(msg.getDouble("lon")*1e-7);
+                alt0=msg.getDouble("alt")*1e-3;
+            }
+            for (int i = 0; i < 4; ++i) {
+                quat[i] = ((Number)((Object[])msg.get("attitude_quaternion"))[i]).doubleValue();
+                // System.out.println("["+quat[0]+","+quat[1]+","+quat[2]+","+quat[3]+"]");
+            }        
+            lat=Math.toRadians(msg.getDouble("lat")*1e-7);
+            lon=Math.toRadians(msg.getDouble("lon")*1e-7);
+            alt=msg.getDouble("alt")*1e-3;
+        
+            Vector3d pos = new Vector3d(EARTH_RADIUS*(lat-lat0),EARTH_RADIUS*(lon-lon0)*Math.cos(lat0),alt0-alt);
+            double [] euler = RotationConversion.eulerAnglesByQuaternion(quat);
+            Matrix3d dcm = new Matrix3d(RotationConversion.rotationMatrixByEulerAngles(euler[0],euler[1],euler[2]));   
+
+            vehicle.setControl(Arrays.asList(control));     // set 0 throttles
+            vehicle.setPosition(pos);   // we want ideally a local pos groundtruth
+            vehicle.setRotation(dcm); 
+            vehicle.updateBranchGroup();
+
+            // System.out.println("pos=["+(int)(pos.x*1000)+", "+(int)(pos.y*1000)+", "+(int)(pos.z*1000)+"]");
+        }
+    }
+
+    @Override
+    public void update(long t, boolean paused) {
+        super.update(t, true);
+   }
+}

--- a/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
+++ b/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
@@ -10,13 +10,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
-// import java.util.Calendar;
-// import java.util.TimeZone;
 
 /**
  * MAVLinkDisplayOnly is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
  * MAVLinkDisplayOnly should have the same sysID as the autopilot, but different componentId.
  * It reads HIL_STATE_QUATERNION from the MAVLink and displays the vehicle position and attitude.
+ * @author Romain Chiappinelli
  */
 public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
 
@@ -32,7 +31,7 @@ public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
     private static final double EARTH_RADIUS=6371000.0;    // earth radius in meters
 
     /**
-     * Create MAVLinkDisplayOnly, MAVLink system that sends simulated sensors to autopilot and passes controls from
+     * Create MAVLinkDisplayOnly, MAVLink system that sends nothing to autopilot and passes states from
      * autopilot to simulator
      *
      * @param sysId       SysId of simulator should be the same as autopilot
@@ -49,14 +48,13 @@ public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
 
             if (fistMsg) {
                 fistMsg=false;
-                // we take the fist received position as initial position
+                // we take the first received position as initial position
                 lat0=Math.toRadians(msg.getDouble("lat")*1e-7);
                 lon0=Math.toRadians(msg.getDouble("lon")*1e-7);
                 alt0=msg.getDouble("alt")*1e-3;
             }
             for (int i = 0; i < 4; ++i) {
                 quat[i] = ((Number)((Object[])msg.get("attitude_quaternion"))[i]).doubleValue();
-                // System.out.println("["+quat[0]+","+quat[1]+","+quat[2]+","+quat[3]+"]");
             }        
             lat=Math.toRadians(msg.getDouble("lat")*1e-7);
             lon=Math.toRadians(msg.getDouble("lon")*1e-7);

--- a/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
+++ b/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
@@ -67,11 +67,8 @@ public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
             Matrix3d dcm = new Matrix3d(RotationConversion.rotationMatrixByEulerAngles(euler[0],euler[1],euler[2]));   
 
             vehicle.setControl(Arrays.asList(control));     // set 0 throttles
-            vehicle.setPosition(pos);   // we want ideally a local pos groundtruth
+            vehicle.setPosition(pos);   // we want ideally a "local" pos groundtruth
             vehicle.setRotation(dcm); 
-            vehicle.updateBranchGroup();
-
-            // System.out.println("pos=["+(int)(pos.x*1000)+", "+(int)(pos.y*1000)+", "+(int)(pos.z*1000)+"]");
         }
     }
 

--- a/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
+++ b/src/me/drton/jmavsim/MAVLinkDisplayOnly.java
@@ -7,9 +7,6 @@ import me.drton.jmavsim.vehicle.AbstractVehicle;
 
 import javax.vecmath.*;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
 
 /**
  * MAVLinkDisplayOnly is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
@@ -17,9 +14,9 @@ import java.util.ArrayList;
  * It reads HIL_STATE_QUATERNION from the MAVLink and displays the vehicle position and attitude.
  * @author Romain Chiappinelli
  */
-public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
+public class MAVLinkDisplayOnly extends MAVLinkHILSystemBase {
 
-    private boolean fistMsg=true;       // to detect the first MAVLink message
+    private boolean firstMsg=true;       // to detect the first MAVLink message
     private double lat0;                // initial latitude (radians)
     private double lon0;                // initial longitude (radians)
     private double alt0;                // initial altitude (meters)
@@ -46,8 +43,8 @@ public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
     public void handleMessage(MAVLinkMessage msg) {
         if ("HIL_STATE_QUATERNION".equals(msg.getMsgName())) {
 
-            if (fistMsg) {
-                fistMsg=false;
+            if (firstMsg) {
+                firstMsg=false;
                 // we take the first received position as initial position
                 lat0=Math.toRadians(msg.getDouble("lat")*1e-7);
                 lon0=Math.toRadians(msg.getDouble("lon")*1e-7);
@@ -71,7 +68,21 @@ public class MAVLinkDisplayOnly extends MAVLinkHILSystem {
     }
 
     @Override
-    public void update(long t, boolean paused) {
-        super.update(t, true);
-   }
+    public boolean gotHilActuatorControls()
+    {
+        return !firstMsg;
+    }
+
+    @Override
+    public void initMavLink()
+    {
+        firstMsg=true;
+    }
+
+    @Override
+    public void endSim()
+    {
+
+    }
+
 }

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -18,8 +18,8 @@ import java.util.TimeZone;
  * MAVLinkHILSystem should have the same sysID as the autopilot, but different componentId.
  */
 public class MAVLinkHILSystem extends MAVLinkSystem {
-    private Simulator simulator;
-    private AbstractVehicle vehicle;
+    protected Simulator simulator;
+    protected AbstractVehicle vehicle;
     private boolean gotHeartBeat = false;
     private boolean inited = false;
     private boolean stopped = false;

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -17,9 +17,9 @@ import java.util.TimeZone;
  * MAVLinkHILSystem is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
  * MAVLinkHILSystem should have the same sysID as the autopilot, but different componentId.
  */
-public class MAVLinkHILSystem extends MAVLinkSystem {
-    private Simulator simulator;
-    protected AbstractVehicle vehicle;
+public class MAVLinkHILSystem extends MAVLinkHILSystemBase {
+    // private Simulator simulator;
+    // private AbstractVehicle vehicle;
     private boolean gotHeartBeat = false;
     private boolean inited = false;
     private boolean stopped = false;
@@ -38,14 +38,10 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
      * @param vehicle     vehicle to connect
      */
     public MAVLinkHILSystem(MAVLinkSchema schema, int sysId, int componentId, AbstractVehicle vehicle) {
-        super(schema, sysId, componentId);
-        this.vehicle = vehicle;
+        super(schema, sysId, componentId, vehicle);
     }
 
-    public void setSimulator(Simulator simulator) {
-        this.simulator = simulator;
-    }
-
+    @Override
     public boolean gotHilActuatorControls() {
         return gotHilActuatorControls;
     }
@@ -147,6 +143,7 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
         }
     }
 
+    @Override
     public void initMavLink() {
         if (vehicle.getSensors().getGPSStartTime() == -1) {
             vehicle.getSensors().setGPSStartTime(simulator.getSimMillis() + 1000);
@@ -155,6 +152,7 @@ public class MAVLinkHILSystem extends MAVLinkSystem {
         inited = true;
     }
 
+    @Override
     public void endSim() {
         if (!inited) {
             return;

--- a/src/me/drton/jmavsim/MAVLinkHILSystem.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystem.java
@@ -18,7 +18,7 @@ import java.util.TimeZone;
  * MAVLinkHILSystem should have the same sysID as the autopilot, but different componentId.
  */
 public class MAVLinkHILSystem extends MAVLinkSystem {
-    protected Simulator simulator;
+    private Simulator simulator;
     protected AbstractVehicle vehicle;
     private boolean gotHeartBeat = false;
     private boolean inited = false;

--- a/src/me/drton/jmavsim/MAVLinkHILSystemBase.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystemBase.java
@@ -4,8 +4,9 @@ import me.drton.jmavlib.mavlink.MAVLinkSchema;
 import me.drton.jmavsim.vehicle.AbstractVehicle;
 
 /**
- * MAVLinkHILSystem is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
- * MAVLinkHILSystem should have the same sysID as the autopilot, but different componentId.
+ * MAVLinkHILSystemBase is the superclass of MAVLinkHILSystem and MAVLinkDisplayOnly. It is a bridge between 
+ * AbstractVehicle and autopilot connected via MAVLink.
+ * MAVLinkHILSystemBase should have the same sysID as the autopilot, but different componentId.
  */
 public abstract class MAVLinkHILSystemBase extends MAVLinkSystem {
     protected Simulator simulator;

--- a/src/me/drton/jmavsim/MAVLinkHILSystemBase.java
+++ b/src/me/drton/jmavsim/MAVLinkHILSystemBase.java
@@ -1,0 +1,37 @@
+package me.drton.jmavsim;
+
+import me.drton.jmavlib.mavlink.MAVLinkSchema;
+import me.drton.jmavsim.vehicle.AbstractVehicle;
+
+/**
+ * MAVLinkHILSystem is MAVLink bridge between AbstractVehicle and autopilot connected via MAVLink.
+ * MAVLinkHILSystem should have the same sysID as the autopilot, but different componentId.
+ */
+public abstract class MAVLinkHILSystemBase extends MAVLinkSystem {
+    protected Simulator simulator;
+    protected AbstractVehicle vehicle;
+
+    /**
+     * Create MAVLinkHILSimulator, MAVLink system that sends simulated sensors to autopilot and passes controls from
+     * autopilot to simulator
+     *
+     * @param sysId       SysId of simulator should be the same as autopilot
+     * @param componentId ComponentId of simulator should be different from autopilot
+     * @param vehicle     vehicle to connect
+     */
+    public MAVLinkHILSystemBase(MAVLinkSchema schema, int sysId, int componentId, AbstractVehicle vehicle) {
+        super(schema, sysId, componentId);
+        this.vehicle = vehicle;
+    }
+
+    public void setSimulator(Simulator simulator) {
+        this.simulator = simulator;
+    }
+
+    public abstract boolean gotHilActuatorControls();
+
+    public abstract void initMavLink();
+
+    public abstract void endSim();
+
+}

--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -958,6 +958,7 @@ public class Simulator implements Runnable {
         System.out.println(DISPLAY_ONLY_STRING);        
         System.out.println("      Disable the simulation engine.");
         System.out.println("      Display the autopilot states from HIL_STATE_QUATERNION.");
+        System.out.println("      Compatible with simulation-in-hardware.");
         System.out.println("");
         System.out.println("Key commands (in the visualizer window):");
         System.out.println("");

--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -371,7 +371,7 @@ public class Simulator implements Runnable {
 
                     System.out.println("Shutting down...");
                     if (hilSystem != null) {
-                        (hilSystem).endSim();
+                        hilSystem.endSim();
                     }
 
                     // Close ports
@@ -489,7 +489,7 @@ public class Simulator implements Runnable {
             // time is not increased.
             boolean ioRunOnly = (slowDownCounter % checkFactor != 0);
 
-            if (!(hilSystem).gotHilActuatorControls() && !ioRunOnly) {
+            if (!hilSystem.gotHilActuatorControls() && !ioRunOnly) {
                 advanceTime();
             }
 


### PR DESCRIPTION
This pull request allows the states of the quadrotor from [simulation-in-hardware](https://dev.px4.io/master/en/simulation/simulation-in-hardware.html) to be displayed in jMAVSim.

By starting with the flag `-displayonly`, jMAVSim enters a mode where the simulation engine is disabled. I created a class `MAVLinkDisplayOnly` that extends `MAVLinkHILSystem`. It sends nothing to the autopilot and passes states from autopilot to simulator. The readed states from `HIL_STATE_QUATERNION` are the position and attitude. 

The documentation is also updated, by starting with the flag `-h`.