### PR TITLE
Serial/TCP/UDP ports: mark messages as forwarded

### DIFF
--- a/src/me/drton/jmavsim/SerialMAVLinkPort.java
+++ b/src/me/drton/jmavsim/SerialMAVLinkPort.java
@@ -144,6 +144,7 @@ public class SerialMAVLinkPort extends MAVLinkPort {
                 if (msg == null) {
                     break;
                 }
+                msg.forwarded = true;
                 sendMessage(msg);
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/me/drton/jmavsim/TCPMavLinkPort.java
+++ b/src/me/drton/jmavsim/TCPMavLinkPort.java
@@ -167,6 +167,7 @@ public class TCPMavLinkPort extends MAVLinkPort {
                     System.out.println("[update] msg.name: " + msg.getMsgName() + ", type: " + msg.getMsgType());
                 }
                 IndicateReceivedMessage(msg.getMsgType());
+                msg.forwarded = true;
                 sendMessage(msg);
             } catch (IOException ignored) {
                 // This can happen when px4 shuts down and the connection is dropped.

--- a/src/me/drton/jmavsim/UDPMavLinkPort.java
+++ b/src/me/drton/jmavsim/UDPMavLinkPort.java
@@ -144,6 +144,7 @@ public class UDPMavLinkPort extends MAVLinkPort {
                     System.out.println("[update] msg.name: " + msg.getMsgName() + ", type: " + msg.getMsgType());
                 }
                 IndicateReceivedMessage(msg.getMsgType());
+                msg.forwarded = true;
                 sendMessage(msg);
             } catch (IOException e) {
                 // Silently ignore this exception, we likely just have nobody on this port yet/already


### PR DESCRIPTION
When we forward a MAVLink message we should not change the sequence number. With this change we are doing that and avoid confusing PX4 which has to assume messages were dropped if the sequence number is not correctly increasing.

By marking the messages as forwarded we prevent the sequence number from being changed in the first place.

After https://github.com/PX4/jMAVlib/pull/15 is merged, the submodule here needs to be updated.

Thanks to @JonasVautherin for the help.