### PR TITLE
src: enable UDP connection in client and host mode

### DIFF
--- a/src/me/drton/jmavsim/Simulator.java
+++ b/src/me/drton/jmavsim/Simulator.java
@@ -234,7 +234,7 @@ public class Simulator implements Runnable {
         } else {
             UDPMavLinkPort port = new UDPMavLinkPort(schema);
             port.setDebug(DEBUG_MODE);
-            port.setup(autopilotIpAddress, autopilotPort);
+            port.setupHost(autopilotPort);
             if (monitorMessage) {
                 port.setMonitorMessageID(monitorMessageIds);
             }
@@ -264,7 +264,7 @@ public class Simulator implements Runnable {
 
             udpGCMavLinkPort = new UDPMavLinkPort(schema);
             udpGCMavLinkPort.setDebug(DEBUG_MODE);
-            udpGCMavLinkPort.setup(qgcIpAddress, qgcPeerPort);
+            udpGCMavLinkPort.setupClient(qgcIpAddress, qgcPeerPort);
             if (monitorMessage && PORT == Port.SERIAL) {
                 udpGCMavLinkPort.setMonitorMessageID(monitorMessageIds);
             }
@@ -284,7 +284,7 @@ public class Simulator implements Runnable {
 
             udpSDKMavLinkPort = new UDPMavLinkPort(schema);
             udpSDKMavLinkPort.setDebug(DEBUG_MODE);
-            udpSDKMavLinkPort.setup(sdkIpAddress, sdkPeerPort);
+            udpSDKMavLinkPort.setupClient(sdkIpAddress, sdkPeerPort);
             if (monitorMessage && PORT == Port.SERIAL) {
                 udpSDKMavLinkPort.setMonitorMessageID(monitorMessageIds);
             }
@@ -625,7 +625,7 @@ public class Simulator implements Runnable {
     }
 
     public final static String PRINT_INDICATION_STRING = "-m [<MsgID[, MsgID]...>]";
-    public final static String UDP_STRING = "-udp <mav ip>:<mav port>";
+    public final static String UDP_STRING = "-udp <mav port>";
     public final static String TCP_STRING = "-tcp <mav ip>:<mav port>";
     public final static String QGC_STRING = "-qgc <qgc ip address>:<qgc peer port>";
     public final static String SDK_STRING = "-sdk <sdk ip address>:<sdk peer port>";
@@ -714,14 +714,7 @@ public class Simulator implements Runnable {
                         continue;
                     }
                     try {
-                        // try to parse passed-in ports.
-                        String[] list = nextArg.split(":");
-                        if (list.length != 2) {
-                            System.err.println("Expected: " + UDP_STRING + ", got: " + Arrays.toString(list));
-                            return;
-                        }
-                        autopilotIpAddress = list[0];
-                        autopilotPort = Integer.parseInt(list[1]);
+                        autopilotPort = Integer.parseInt(nextArg);
                     } catch (NumberFormatException e) {
                         System.err.println("Expected: " + USAGE_STRING + ", got: " + e.toString());
                         return;

--- a/src/me/drton/jmavsim/UDPMavLinkPort.java
+++ b/src/me/drton/jmavsim/UDPMavLinkPort.java
@@ -49,20 +49,37 @@ public class UDPMavLinkPort extends MAVLinkPort {
         this.debug = debug;
     }
 
-    public void setup(String peerAddress, int peerPort) throws UnknownHostException, IOException {
+    public void setupClient(String peerAddress, int peerPort) throws UnknownHostException, IOException {
         this.peerPort = new InetSocketAddress(peerAddress, peerPort);
         this.bindPort = new InetSocketAddress("0.0.0.0", 0);
         if (debug) {
             System.out.println("peerAddress: " + this.peerPort.toString() + ", bindAddress: " +
                                this.bindPort.toString());
         }
-    }
 
-    public void open() throws IOException {
         channel = DatagramChannel.open();
         channel.socket().bind(bindPort);
         channel.configureBlocking(false);
-        channel.connect(peerPort);
+        channel.connect(this.peerPort);
+    }
+
+    public void setupHost(int peerPort) throws UnknownHostException, IOException {
+        //this.peerPort = new InetSocketAddress(peerAddress, 0);
+        this.bindPort = new InetSocketAddress("0.0.0.0", peerPort);
+        if (debug) {
+            System.out.println("peerAddress: " + this.peerPort.toString() + ", bindAddress: " +
+                               this.bindPort.toString());
+        }
+
+        channel = DatagramChannel.open();
+        channel.socket().bind(bindPort);
+        channel.configureBlocking(true);
+        this.peerPort = channel.receive(this.rxBuffer);
+        channel.configureBlocking(false);
+        channel.connect(this.peerPort);
+    }
+
+    public void open() throws IOException {
         stream = new MAVLinkStream(schema, channel);
         stream.setDebug(debug);
     }

--- a/src/me/drton/jmavsim/UDPMavLinkPort.java
+++ b/src/me/drton/jmavsim/UDPMavLinkPort.java
@@ -64,17 +64,13 @@ public class UDPMavLinkPort extends MAVLinkPort {
     }
 
     public void setupHost(int peerPort) throws UnknownHostException, IOException {
-        //this.peerPort = new InetSocketAddress(peerAddress, 0);
         this.bindPort = new InetSocketAddress("0.0.0.0", peerPort);
-        if (debug) {
-            System.out.println("peerAddress: " + this.peerPort.toString() + ", bindAddress: " +
-                               this.bindPort.toString());
-        }
-
         channel = DatagramChannel.open();
         channel.socket().bind(bindPort);
         channel.configureBlocking(true);
+        System.out.println("waiting for first message from: " + this.bindPort.toString());
         this.peerPort = channel.receive(this.rxBuffer);
+        System.out.println("received first message from: " + this.peerPort.toString());
         channel.configureBlocking(false);
         channel.connect(this.peerPort);
     }


### PR DESCRIPTION
This changes the UDPMavLinkPort class to accept a setup as client or host which enables to receive MAVLink on UDP from a drone on a given port (host) but also allows to send MAVLink to a given port to forward it to QGC or an SDK (client).